### PR TITLE
add shamir secret sharing on secp256k1 field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bench_inv
 bench_ecdh
 bench_ecmult
 bench_schnorrsig
+bench_sss
 bench_sign
 bench_verify
 bench_recover

--- a/Makefile.am
+++ b/Makefile.am
@@ -162,3 +162,7 @@ endif
 if ENABLE_MODULE_SCHNORRSIG
 include src/modules/schnorrsig/Makefile.am.include
 endif
+
+if ENABLE_MODULE_SSS
+include src/modules/sss/Makefile.am.include
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -141,6 +141,11 @@ AC_ARG_ENABLE(module_schnorrsig,
     [enable_module_schnorrsig=$enableval],
     [enable_module_schnorrsig=no])
 
+AC_ARG_ENABLE(module_sss,
+    AS_HELP_STRING([--enable-module-sss],[enable shamir secret sharing module (experimental)]),
+    [enable_module_sss=$enableval],
+    [enable_module_sss=no])
+
 AC_ARG_ENABLE(external_default_callbacks,
     AS_HELP_STRING([--enable-external-default-callbacks],[enable external default callback functions [default=no]]),
     [use_external_default_callbacks=$enableval],
@@ -447,6 +452,10 @@ if test x"$enable_module_extrakeys" = x"yes"; then
   AC_DEFINE(ENABLE_MODULE_EXTRAKEYS, 1, [Define this symbol to enable the extrakeys module])
 fi
 
+if test x"$enable_module_sss" = x"yes"; then
+  AC_DEFINE(ENABLE_MODULE_SSS, 1, [Define this symbol to enable the shamir secret sharing module])
+fi
+
 if test x"$use_external_asm" = x"yes"; then
   AC_DEFINE(USE_EXTERNAL_ASM, 1, [Define this symbol if an external (non-inline) assembly implementation is used])
 fi
@@ -461,6 +470,7 @@ if test x"$enable_experimental" = x"yes"; then
   AC_MSG_NOTICE([Experimental features do not have stable APIs or properties, and may not be safe for production use.])
   AC_MSG_NOTICE([Building extrakeys module: $enable_module_extrakeys])
   AC_MSG_NOTICE([Building schnorrsig module: $enable_module_schnorrsig])
+  AC_MSG_NOTICE([Building sss module: $enable_module_sss])
   AC_MSG_NOTICE([******])
 else
   if test x"$enable_module_extrakeys" = x"yes"; then
@@ -468,6 +478,9 @@ else
   fi
   if test x"$enable_module_schnorrsig" = x"yes"; then
     AC_MSG_ERROR([schnorrsig module is experimental. Use --enable-experimental to allow.])
+  fi
+  if test x"$enable_module_sss" = x"yes"; then
+    AC_MSG_ERROR([sss module is experimental. Use --enable-experimental to allow.])
   fi
   if test x"$set_asm" = x"arm"; then
     AC_MSG_ERROR([ARM assembly optimization is experimental. Use --enable-experimental to allow.])
@@ -489,6 +502,7 @@ AM_CONDITIONAL([ENABLE_MODULE_ECDH], [test x"$enable_module_ecdh" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_RECOVERY], [test x"$enable_module_recovery" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_EXTRAKEYS], [test x"$enable_module_extrakeys" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_SCHNORRSIG], [test x"$enable_module_schnorrsig" = x"yes"])
+AM_CONDITIONAL([ENABLE_MODULE_SSS], [test x"$enable_module_sss" = x"yes"])
 AM_CONDITIONAL([USE_EXTERNAL_ASM], [test x"$use_external_asm" = x"yes"])
 AM_CONDITIONAL([USE_ASM_ARM], [test x"$set_asm" = x"arm"])
 
@@ -511,6 +525,7 @@ echo "  module ecdh             = $enable_module_ecdh"
 echo "  module recovery         = $enable_module_recovery"
 echo "  module extrakeys        = $enable_module_extrakeys"
 echo "  module schnorrsig       = $enable_module_schnorrsig"
+echo "  module sss              = $enable_module_sss"
 echo
 echo "  asm                     = $set_asm"
 echo "  bignum                  = $set_bignum"

--- a/include/secp256k1_sss.h
+++ b/include/secp256k1_sss.h
@@ -1,0 +1,79 @@
+#ifndef SECP256K1_SSS_H
+#define SECP256K1_SSS_H
+
+#include "secp256k1.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Create shamir shares for a secret key with given polynomial coefficients in secp256k1 finite field.
+ *
+ *  Shamir secret sharing can share a secret key between n parties with threshold t.
+ *  Secret key can not be reconstructed if and only if more than t parties reveal 
+ *  their secret shares.
+ * 
+ *  This implementation uses Xi = i + 1 as x-coordinate for party i (start from 0). So the result share
+ *  point for each party can be expressed by a one-dimension array with only y-coordinate.
+ *  
+ *  Returns: 1 if secret key is succesfully shared, 0 otherwise.
+ * 
+ *  Args:   ctx:                pointer to a context object (cannot be NULL).
+ *  Out:    out:                pointer to a two dimension array with space of {share_count} * 32 bytes.
+ *                              each 32-byte data at position i (start from 0) represents a secret point
+ *                              (Xi, Yi) = (i + 1, out[i]) for party-i. (cannot be NULL).
+ *  In:     secret              pointer to a 32-byte secret number to be shared (cannot be NULL).
+ *          coefficients:       pointer to a two dimension array with {threshold} random coefficients
+ *                              for polynomial. each coefficient is a 32-byte unsigned char array.
+ *                              coefficient at position i (start from 0) will be multipled by x^(i + 1).
+ *                              (cannot be NULL).
+ *          threshold:          threshold for reconstructing share. secret key can be reconstructed only 
+ *                              with party count > threshold.
+ *          share_count:        total number of parties to hold shares.
+ *          coefficients_buffer:buffer to save scalar representation for coefficients. should contain space
+ *                              for {threshold + 1} scalars. all the buffered data will be cleared before
+ *                              return (cannot be NULL).
+ * 
+ * coefficients buffer can be allocated using:
+ * secp256k1_scratch_space_create(ctx, sizeof(secp256k1_scalar) * (threshold + 1));
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_sss_share_create(
+    const secp256k1_context* ctx,
+    unsigned char out[][32],
+    const unsigned char *secret,
+    unsigned char coefficients[][32],
+    size_t threshold,
+    size_t share_count,
+    secp256k1_scratch_space * coefficients_buffer
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(7);
+
+/** Get additive share which can be used to reconstruct original secret value by add operation on finite
+ *  field of secp256k1.
+ *
+ *  Additive share is defined to be L*share, where L is the lagrange coefficient for party's share, based
+ *  on participant party ids when reconstructing secret.
+ *  
+ *  Returns: 0 if the arguments are invalid. 1 otherwise.
+ * 
+ *  Args:   ctx:        pointer to a context object (cannot be NULL).
+ *  Out:    out:        pointer to a 32-byte array for addtive key result (cannot be NULL).
+ *  In:     share       pointer to a 32-byte secret share (cannot be NULL).
+ *          parties     pointer to an integer array with {threshold + 1} party id items. current
+ *                      party id need also be included. (cannot be NULL).
+ *          threshold:  threshold for reconstructing share.
+ *          index:      current party id.
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_sss_get_additive_share(
+    const secp256k1_context* ctx,
+    unsigned char* out,
+    const unsigned char* share,
+    const size_t * parties,
+    size_t threshold,
+    size_t index
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/bench_sss.c
+++ b/src/bench_sss.c
@@ -1,0 +1,160 @@
+/***********************************************************************
+ * Copyright (c) 2020-2021 JK Zhou                                     *
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
+#include "include/secp256k1.h"
+#include "include/secp256k1_sss.h"
+#include "field_impl.h"
+#include "scalar_impl.h"
+
+#include "util.h"
+#include "bench.h"
+
+typedef struct {
+    secp256k1_context* ctx;
+    size_t threshold;
+    size_t share_count;
+    unsigned char secret[32];
+    unsigned char (*out_shares)[32];
+    unsigned char (*coefficients)[32];
+    secp256k1_scratch_space * coefficients_buffer;
+} bench_sss_data;
+
+static void bench_sss_setup(size_t threshold, size_t share_count, void* arg) {
+    size_t i, j;
+    bench_sss_data *data = (bench_sss_data*)arg;
+
+    data->threshold = threshold;
+    data->share_count = share_count;
+    data->out_shares = (unsigned char (*)[32])malloc(32 * share_count);
+    data->coefficients = (unsigned char (*)[32])malloc(32 * threshold);
+    for(i = 0; i < 32; i++) {
+        data->secret[i] = i + 1;
+    }
+    for(i = 0; i < threshold; i++) {
+        for(j = 0; j < 32; j++) {
+            data->coefficients[i][j] = ((i << 5) | j) + 65;
+        }
+    }
+    data->coefficients_buffer = secp256k1_scratch_space_create(
+        data->ctx, sizeof(secp256k1_scalar) * (threshold + 1));
+}
+
+static void bench_sss_setup_1_2(void* arg) { bench_sss_setup(1, 2, arg); }
+static void bench_sss_setup_2_3(void* arg) { bench_sss_setup(2, 3, arg); }
+static void bench_sss_setup_3_5(void* arg) { bench_sss_setup(3, 5, arg); }
+static void bench_sss_setup_5_8(void* arg) { bench_sss_setup(5, 8, arg); }
+static void bench_sss_setup_10_20(void* arg) { bench_sss_setup(10, 20, arg); }
+
+static void bench_sss_setup_20_30(void* arg) { bench_sss_setup(20, 30, arg); }
+static void bench_sss_setup_20_40(void* arg) { bench_sss_setup(20, 40, arg); }
+static void bench_sss_setup_20_60(void* arg) { bench_sss_setup(20, 60, arg); }
+static void bench_sss_setup_20_80(void* arg) { bench_sss_setup(20, 80, arg); }
+
+static void bench_sss_teardown(void *arg, int iters) {
+    bench_sss_data *data = (bench_sss_data*)arg;
+    iters = iters; /* to avoid compiler unused-parameter warning */
+    secp256k1_scratch_space_destroy(data->ctx, data->coefficients_buffer);
+    free(data->out_shares);
+    free(data->coefficients);
+}
+
+static void bench_sss_run(void* arg, int iters) {
+    int i;
+    bench_sss_data *data = (bench_sss_data*)arg;
+    for (i = 0; i < iters; i++) {
+    CHECK(secp256k1_sss_share_create(
+        data->ctx, data->out_shares, data->secret, data->coefficients,
+        data->threshold, data->share_count, data->coefficients_buffer));
+    }
+}
+
+static void bench_share_get_setup(size_t threshold, size_t share_count, void* arg) {
+    bench_sss_data *data = (bench_sss_data*)arg;
+    bench_sss_setup(threshold, share_count, arg);
+    CHECK(secp256k1_sss_share_create(
+        data->ctx, data->out_shares, data->secret, data->coefficients,
+        data->threshold, data->share_count, data->coefficients_buffer));
+}
+
+static void bench_share_get_setup_1_2(void* arg) { bench_share_get_setup(1, 2, arg); }
+static void bench_share_get_setup_2_3(void* arg) { bench_share_get_setup(2, 3, arg); }
+static void bench_share_get_setup_3_5(void* arg) { bench_share_get_setup(3, 5, arg); }
+static void bench_share_get_setup_5_8(void* arg) { bench_share_get_setup(5, 8, arg); }
+static void bench_share_get_setup_10_20(void* arg) { bench_share_get_setup(10, 20, arg); }
+
+static void bench_share_get_setup_20_30(void* arg) { bench_share_get_setup(20, 30, arg); }
+static void bench_share_get_setup_20_40(void* arg) { bench_share_get_setup(20, 40, arg); }
+static void bench_share_get_setup_20_60(void* arg) { bench_share_get_setup(20, 60, arg); }
+static void bench_share_get_setup_20_80(void* arg) { bench_share_get_setup(20, 80, arg); }
+static void bench_share_get_teardown(void *arg, int iters) {
+    bench_sss_teardown(arg, iters);
+}
+
+static void bench_share_get_run(void* arg, int iters) {
+    size_t i, j;
+    unsigned char (*res)[32];
+    size_t *parties;
+    int ret = 1;
+
+    bench_sss_data* data = (bench_sss_data*)arg;
+    parties = (size_t*)malloc(sizeof(size_t) * (data->threshold + 1));
+    res = (unsigned char (*)[32])malloc(32 * (data->threshold + 1));
+
+    /* split iters into iters / (threshold + 1) round 
+     * and run (threshold + 1) recoveries in each round
+     * */
+    for (i = 0; i < iters / (data->threshold + 1); i++) {
+        /* prepare party ids for current loop */
+        for(j = 0; j < data->threshold + 1; j++) {
+            parties[j] = 1 + (i + j) % data->share_count;
+        }
+        
+        /* for each selected party, recover it's share */
+        for(j = 0; j < data->threshold + 1; j++) {
+            CHECK(secp256k1_sss_get_additive_share(
+                data->ctx, res[j], data->out_shares[parties[j] - 1],
+                parties, data->threshold, parties[j]));
+        }
+        for(j = 1; j < data->threshold + 1; j++) {
+            ret = ret && secp256k1_ec_privkey_tweak_add(data->ctx, res[0], res[j]);
+        }
+        CHECK(secp256k1_memcmp_var(res[0], data->secret, 32) == 0);
+    }
+    free(parties);
+    free(res);
+}
+
+int main(void) {
+    bench_sss_data data;
+    int iters;
+    data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+
+    iters = get_iters(20000);
+    run_benchmark("shamir_secret_sharing_1_2", bench_sss_run, bench_sss_setup_1_2, bench_sss_teardown, &data, 10, iters);
+    run_benchmark("shamir_secret_sharing_2_3", bench_sss_run, bench_sss_setup_2_3, bench_sss_teardown, &data, 10, iters);
+    run_benchmark("shamir_secret_sharing_3_5", bench_sss_run, bench_sss_setup_3_5, bench_sss_teardown, &data, 10, iters);
+    run_benchmark("shamir_secret_sharing_5_8", bench_sss_run, bench_sss_setup_5_8, bench_sss_teardown, &data, 10, iters);
+    run_benchmark("shamir_secret_sharing_10_20", bench_sss_run, bench_sss_setup_10_20, bench_sss_teardown, &data, 10, iters);
+
+    run_benchmark("shamir_secret_sharing_20_30", bench_sss_run, bench_sss_setup_20_30, bench_sss_teardown, &data, 10, iters);
+    run_benchmark("shamir_secret_sharing_20_40", bench_sss_run, bench_sss_setup_20_40, bench_sss_teardown, &data, 10, iters);
+    run_benchmark("shamir_secret_sharing_20_60", bench_sss_run, bench_sss_setup_20_60, bench_sss_teardown, &data, 10, iters);
+    run_benchmark("shamir_secret_sharing_20_80", bench_sss_run, bench_sss_setup_20_80, bench_sss_teardown, &data, 10, iters);
+
+    run_benchmark("recover_secret_share_1_2", bench_share_get_run, bench_share_get_setup_1_2, bench_share_get_teardown, &data, 10, iters);
+    run_benchmark("recover_secret_share_2_3", bench_share_get_run, bench_share_get_setup_2_3, bench_share_get_teardown, &data, 10, iters);
+    run_benchmark("recover_secret_share_3_5", bench_share_get_run, bench_share_get_setup_3_5, bench_share_get_teardown, &data, 10, iters);
+    run_benchmark("recover_secret_share_5_8", bench_share_get_run, bench_share_get_setup_5_8, bench_share_get_teardown, &data, 10, iters);
+    run_benchmark("recover_secret_share_10_20", bench_share_get_run, bench_share_get_setup_10_20, bench_share_get_teardown, &data, 10, iters);
+
+    run_benchmark("recover_secret_share_20_30", bench_share_get_run, bench_share_get_setup_20_30, bench_share_get_teardown, &data, 10, iters);
+    run_benchmark("recover_secret_share_20_40", bench_share_get_run, bench_share_get_setup_20_40, bench_share_get_teardown, &data, 10, iters);
+    run_benchmark("recover_secret_share_20_60", bench_share_get_run, bench_share_get_setup_20_60, bench_share_get_teardown, &data, 10, iters);
+    run_benchmark("recover_secret_share_20_80", bench_share_get_run, bench_share_get_setup_20_80, bench_share_get_teardown, &data, 10, iters);
+
+    secp256k1_context_destroy(data.ctx);
+    return 0;
+}

--- a/src/modules/sss/Makefile.am.include
+++ b/src/modules/sss/Makefile.am.include
@@ -1,0 +1,8 @@
+include_HEADERS += include/secp256k1_sss.h
+noinst_HEADERS += src/modules/sss/main_impl.h
+noinst_HEADERS += src/modules/sss/tests_impl.h
+if USE_BENCHMARK
+noinst_PROGRAMS += bench_sss
+bench_sss_SOURCES = src/bench_sss.c
+bench_sss_LDADD = libsecp256k1.la $(SECP_LIBS) $(COMMON_LIB)
+endif

--- a/src/modules/sss/main_impl.h
+++ b/src/modules/sss/main_impl.h
@@ -1,0 +1,110 @@
+#ifndef _SECP256K1_MODULE_SSS_MAIN_
+#define _SECP256K1_MODULE_SSS_MAIN_
+
+#include "include/secp256k1.h"
+#include "include/secp256k1_sss.h"
+
+#include "scalar_impl.h"
+
+#define SCALA_AT(scratch, i) (((secp256k1_scalar*)scratch->data)[i])
+
+int secp256k1_sss_share_create(
+    const secp256k1_context* ctx,
+    unsigned char out[][32],
+    const unsigned char *secret,
+    /* const unsigned char coefficients[][32], */
+    unsigned char coefficients[][32],
+    size_t threshold,
+    size_t share_count,
+    secp256k1_scratch_space * coefficient_buffer
+) {
+    size_t i, j;
+    int ret = 1;
+    int overflow = 0;
+    secp256k1_scalar share, x;
+
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
+    ARG_CHECK(threshold > 0);
+    ARG_CHECK(share_count > threshold);
+    ARG_CHECK(out != NULL);
+    ARG_CHECK(secret != NULL);
+    ARG_CHECK(coefficients != NULL);
+    VERIFY_CHECK(coefficient_buffer != NULL);
+
+    /* prepare polynomial coefficients */
+    secp256k1_scalar_set_b32(&SCALA_AT(coefficient_buffer, 0), secret, &overflow);
+    ret &= !overflow;
+    for(i = 1; i <= threshold; i++) {
+        secp256k1_scalar_set_b32(&SCALA_AT(coefficient_buffer, i), coefficients[i - 1], &overflow);
+        ret &= !overflow;
+    }
+
+    for(i = 0; i < share_count; i++) {
+        /* evaluate polynomial */
+        secp256k1_scalar_set_int(&x, i + 1);
+        secp256k1_scalar_cmov(&share, &SCALA_AT(coefficient_buffer, threshold), ret);
+        for(j = threshold - 1; j < threshold; j--) {
+            secp256k1_scalar_mul(&share, &share, &x);
+            secp256k1_scalar_add(&share, &share, &SCALA_AT(coefficient_buffer, j)); 
+        }
+        secp256k1_scalar_get_b32(out[i], &share);
+    }
+    secp256k1_scalar_clear(&share);
+    secp256k1_scalar_clear(&x);
+    memset(coefficient_buffer->data, 0, sizeof(secp256k1_scalar) * (threshold + 1));
+    return ret;
+}
+
+int secp256k1_sss_get_additive_share(
+    const secp256k1_context* ctx,
+    unsigned char* out,
+    const unsigned char* share,
+    const size_t * parties,
+    size_t threshold,
+    size_t index
+) {
+    secp256k1_scalar nag_xi, denum, party_i, r;
+    size_t i;
+    int ret = 1;
+    int overflow = 0;
+
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
+    ARG_CHECK(out != NULL);
+    ARG_CHECK(share != NULL);
+    ARG_CHECK(parties != NULL);
+    ARG_CHECK(threshold > 0);
+    ARG_CHECK(index > 0);
+    for(i = 0; i <= threshold; i++) {
+        ARG_CHECK(parties[i] > 0);
+    }
+    
+    secp256k1_scalar_set_b32(&r, share, &overflow);
+    ret &= !overflow;
+
+    secp256k1_scalar_set_int(&nag_xi, index);
+    secp256k1_scalar_negate(&nag_xi, &nag_xi);
+    secp256k1_scalar_set_int(&denum, 1);
+    for(i = 0; i <= threshold; i++) {
+        if(parties[i] == index) {
+            continue;
+        }
+        secp256k1_scalar_set_int(&party_i, parties[i]);
+        secp256k1_scalar_mul(&r, &r, &party_i);
+        secp256k1_scalar_add(&party_i, &party_i, &nag_xi);
+        secp256k1_scalar_mul(&denum, &denum, &party_i);
+    }
+    secp256k1_scalar_inverse(&denum, &denum);
+    secp256k1_scalar_mul(&r, &r, &denum);
+    if(ret) {
+        secp256k1_scalar_get_b32(out, &r);
+    }
+    secp256k1_scalar_clear(&nag_xi);
+    secp256k1_scalar_clear(&denum);
+    secp256k1_scalar_clear(&party_i);
+    secp256k1_scalar_clear(&r);
+    return ret;
+}
+
+#endif

--- a/src/modules/sss/tests_impl.h
+++ b/src/modules/sss/tests_impl.h
@@ -1,0 +1,84 @@
+#ifndef _SECP256K1_MODULE_SSS_TESTS_
+#define _SECP256k1_MODULE_SSS_TESTS_
+
+#include "secp256k1_sss.h"
+
+/* threshold = 2
+ * share_count = 5
+ */
+void test_secret_sharing(size_t threshold, size_t share_count, size_t selected_parties[]) {
+    unsigned char secret[32];
+    unsigned char (*out_shares)[32];
+    unsigned char (*coefficients)[32];
+    unsigned char (*test_shares)[32];
+    size_t i;
+    int ret;
+    secp256k1_scratch_space * coefficients_buffer;
+
+    out_shares = (unsigned char (*)[32])malloc(32 * share_count);
+    coefficients = (unsigned char (*)[32])malloc(32 * threshold);
+    test_shares = (unsigned char (*)[32])malloc(32 * (threshold + 1));
+    coefficients_buffer = secp256k1_scratch_space_create(
+        ctx, sizeof(secp256k1_scalar) * (threshold + 1));
+    secp256k1_testrand256(secret);
+
+    for(i = 0; i < threshold; i++) {
+        secp256k1_testrand256(coefficients[i]);
+    }
+
+    ret = secp256k1_sss_share_create(ctx, out_shares, secret, coefficients, threshold, share_count, coefficients_buffer);
+    for(i = 0; i < threshold + 1; i++) {
+        ret = ret && secp256k1_sss_get_additive_share(ctx, test_shares[i], out_shares[selected_parties[i] - 1], selected_parties, threshold, selected_parties[i]);
+    }
+
+    for(i = 1; i < threshold + 1; i++) {
+        ret = ret && secp256k1_ec_privkey_tweak_add(ctx, test_shares[0], test_shares[i]);
+    }
+    CHECK(ret == 1);
+    CHECK(secp256k1_memcmp_var(secret, test_shares[0], 32) == 0);
+    free(out_shares);
+    free(coefficients);
+    free(test_shares);
+    secp256k1_scratch_space_destroy(ctx, coefficients_buffer);
+}
+
+void run_sss_tests(void) {
+    unsigned int i;
+
+    size_t selected_parties_2_1[][2] = {
+        {1,2},
+        {2,1}
+    };
+
+    size_t selected_parties_3_1[][2] = {
+        {1,2}, {1,3}, {2,3}, {3,1}
+    };
+
+    size_t selected_parties_4_2[][3] = {
+        {1,2,3}, {1,2,4}, {1,3,4}, {2,3,4}
+    };
+    
+    size_t selected_parties_5_2[][3] = {
+        {1,2,3}, {1,2,4}, {1,2,5},
+        {2,3,4}, {2,3,5},
+        {3,4,5},
+        {5,4,3}, {3,2,1}, {5,1,2}
+    };
+
+    for(i = 0; i < sizeof(selected_parties_2_1) / sizeof(size_t) / 2; i++) {
+        test_secret_sharing(1, 2, selected_parties_2_1[i]);
+    }
+
+    for(i = 0; i < sizeof(selected_parties_3_1) / sizeof(size_t) / 2; i++) {
+        test_secret_sharing(1, 3, selected_parties_3_1[i]);
+    }
+
+    for(i = 0; i < sizeof(selected_parties_4_2) / sizeof(size_t) / 3; i++) {
+        test_secret_sharing(2, 4, selected_parties_4_2[i]);
+    }
+
+    for(i = 0; i < sizeof(selected_parties_5_2) / sizeof(size_t) / 3; i++) {
+        test_secret_sharing(2, 5, selected_parties_5_2[i]);
+    }
+}
+#endif

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -774,3 +774,7 @@ int secp256k1_ec_pubkey_combine(const secp256k1_context* ctx, secp256k1_pubkey *
 #ifdef ENABLE_MODULE_SCHNORRSIG
 # include "modules/schnorrsig/main_impl.h"
 #endif
+
+#ifdef ENABLE_MODULE_SSS
+# include "modules/sss/main_impl.h"
+#endif

--- a/src/tests.c
+++ b/src/tests.c
@@ -5444,6 +5444,10 @@ void run_ecdsa_openssl(void) {
 # include "modules/schnorrsig/tests_impl.h"
 #endif
 
+#ifdef ENABLE_MODULE_SSS
+# include "modules/sss/tests_impl.h"
+#endif
+
 void run_secp256k1_memczero_test(void) {
     unsigned char buf1[6] = {1, 2, 3, 4, 5, 6};
     unsigned char buf2[sizeof(buf1)];
@@ -5729,6 +5733,10 @@ int main(int argc, char **argv) {
 
 #ifdef ENABLE_MODULE_SCHNORRSIG
     run_schnorrsig_tests();
+#endif
+
+#ifdef ENABLE_MODULE_SSS
+    run_sss_tests();
 #endif
 
     /* util tests */


### PR DESCRIPTION
to allow shamir secret sharing module:
```bash
# ./configure --enable-experimental --enable-module-sss
# make
```

to use shamir secret sharing module:
```C
#include "secp256k1_sss.h"

/*
 *  use secp256k1_sss_share_create to create shares for a secret.
 *  use secp256k1_sss_get_additive_share to get additive key for one party.
 */
```